### PR TITLE
Use Hardware Pulse Counter to support higher frequencies.

### DIFF
--- a/src/FreqCountESP.cpp
+++ b/src/FreqCountESP.cpp
@@ -4,14 +4,74 @@ volatile uint8_t _FreqCountESP::sIsFrequencyReady = false;
 volatile uint32_t _FreqCountESP::sCount = 0;
 volatile uint32_t _FreqCountESP::sFrequency = 0;
 
-portMUX_TYPE _FreqCountESP::sMux = portMUX_INITIALIZER_UNLOCKED;
+#ifdef USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
 
-void IRAM_ATTR onRise()
+volatile uint32_t _FreqCountESP::sLastPcnt = 0;
+
+#define PCNT_HIGH_LIMIT 32767  // largest +ve value for int16_t.
+#define PCNT_LOW_LIMIT  0
+
+#define PCNT_UNIT PCNT_UNIT_0
+#define PCNT_CHANNEL PCNT_CHANNEL_0
+
+portMUX_TYPE pcntMux = portMUX_INITIALIZER_UNLOCKED;
+
+static void IRAM_ATTR onHLim(void *backupCounter)
+{
+  // 16 bit pulse counter hit high limit; increment the 32 bit backup.
+  portENTER_CRITICAL_ISR(&pcntMux);
+  *(volatile uint32_t *)backupCounter += PCNT_HIGH_LIMIT;
+  PCNT.int_clr.val = BIT(PCNT_UNIT);  // Clear the interrupt.
+  portEXIT_CRITICAL_ISR(&pcntMux);
+}
+
+static pcnt_isr_handle_t setupPcnt(uint8_t pin, volatile uint32_t *backupCounter) { 
+  pcnt_config_t pcntConfig = {
+    .pulse_gpio_num = pin,
+    .ctrl_gpio_num = -1,
+    .pos_mode = PCNT_CHANNEL_EDGE_ACTION_INCREASE,
+    .neg_mode = PCNT_CHANNEL_EDGE_ACTION_HOLD,
+    .counter_h_lim = PCNT_HIGH_LIMIT,
+    .counter_l_lim = PCNT_LOW_LIMIT,
+    .unit = PCNT_UNIT,
+    .channel = PCNT_CHANNEL,
+  };
+  pcnt_unit_config(&pcntConfig);
+  pcnt_counter_pause(PCNT_UNIT);
+  pcnt_counter_clear(PCNT_UNIT);
+  pcnt_event_enable(PCNT_UNIT, PCNT_EVT_H_LIM);  // Interrupt on high limit.
+  pcnt_isr_handle_t isrHandle;
+  pcnt_isr_register(onHLim, (void *)backupCounter, 0, &isrHandle);
+  pcnt_intr_enable(PCNT_UNIT);
+  pcnt_counter_resume(PCNT_UNIT);
+  return isrHandle;
+}
+
+void IRAM_ATTR onTimer()
 {
   portENTER_CRITICAL_ISR(&_FreqCountESP::sMux);
-  _FreqCountESP::sCount++;
+  int16_t pulseCount;
+  uint32_t pcntTotal = _FreqCountESP::sCount;
+  pcnt_get_counter_value(PCNT_UNIT, &pulseCount);
+  if (pulseCount < 1000) {
+    // Maybe counter just rolled over? Re-read 32 bit basis.
+    pcntTotal = _FreqCountESP::sCount;
+  }
+  pcntTotal += pulseCount;
+  _FreqCountESP::sFrequency = (uint32_t)(pcntTotal - _FreqCountESP::sLastPcnt);
+  _FreqCountESP::sLastPcnt = pcntTotal;
+  _FreqCountESP::sIsFrequencyReady = true;
   portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
 }
+
+void teardownPcnt(pcnt_isr_handle_t isrHandle)
+{
+  pcnt_counter_pause(PCNT_UNIT);
+  pcnt_intr_disable(PCNT_UNIT);
+  pcnt_isr_unregister(isrHandle);
+}
+
+#else // !USE_PCNT
 
 void IRAM_ATTR onTimer()
 {
@@ -19,6 +79,16 @@ void IRAM_ATTR onTimer()
   _FreqCountESP::sFrequency = _FreqCountESP::sCount;
   _FreqCountESP::sCount = 0;
   _FreqCountESP::sIsFrequencyReady = true;
+  portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
+}
+#endif // !USE_PCNT
+
+portMUX_TYPE _FreqCountESP::sMux = portMUX_INITIALIZER_UNLOCKED;
+
+void IRAM_ATTR onRise()
+{
+  portENTER_CRITICAL_ISR(&_FreqCountESP::sMux);
+  _FreqCountESP::sCount++;
   portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
 }
 
@@ -42,7 +112,12 @@ void _FreqCountESP::begin(uint8_t pin, uint16_t timerMs, uint8_t hwTimerId, uint
 
   pinMode(mPin, mode);
 
+#ifdef USE_PCNT
+  _FreqCountESP::sLastPcnt = 0;
+  mIsrHandle = setupPcnt(mPin, &_FreqCountESP::sCount);
+#else  // !USE_PCNT
   attachInterrupt(mPin, &onRise, RISING);
+#endif  // USE_PCNT
 
   mTimer = timerBegin(hwTimerId, 80, true);
   timerAttachInterrupt(mTimer, &onTimer, true);
@@ -63,7 +138,11 @@ uint8_t _FreqCountESP::available()
 
 void _FreqCountESP::end()
 {
+#ifdef USE_PCNT
+  teardownPcnt(mIsrHandle);
+#else 
   detachInterrupt(mPin);
+#endif
 
   timerAlarmDisable(mTimer);
   timerDetachInterrupt(mTimer);

--- a/src/FreqCountESP.cpp
+++ b/src/FreqCountESP.cpp
@@ -5,6 +5,8 @@ volatile uint32_t _FreqCountESP::sCount = 0;
 volatile uint32_t _FreqCountESP::sFrequency = 0;
 
 #ifdef USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
+// Thanks to jgustavoam and Rui Viana for tips gleaned from
+// https://www.esp32.com/viewtopic.php?t=17018
 
 volatile uint32_t _FreqCountESP::sLastPcnt = 0;
 

--- a/src/FreqCountESP.h
+++ b/src/FreqCountESP.h
@@ -3,6 +3,15 @@
 
 #include <Arduino.h>
 
+#define USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
+
+#ifdef USE_PCNT
+extern "C" {
+  #include "soc/pcnt_struct.h"
+}
+#include <driver/pcnt.h>
+#endif
+
 void IRAM_ATTR onRise();
 void IRAM_ATTR onTimer();
 
@@ -12,11 +21,17 @@ private:
   uint8_t mPin;
   uint16_t mTimerMs;
   hw_timer_t *mTimer;
+#ifdef USE_PCNT
+  pcnt_isr_handle_t mIsrHandle;
+#endif
 
 public:
   static volatile uint8_t sIsFrequencyReady;
   static volatile uint32_t sCount;
   static volatile uint32_t sFrequency;
+#ifdef USE_PCNT
+  static volatile uint32_t sLastPcnt;
+#endif
 
   static portMUX_TYPE sMux;
 


### PR DESCRIPTION
Thanks for the very clean FreqCountESP class.

I wanted to use it to measure my new 10 MHz OCXO.  However, getting input pulses at 10 MHz overwhelmed the interrupt handler and the code wouldn't run.

It turns out that the ESP32 has a hardware pulse counter, ```pcnt```.  This patch adapts FreqCountESP to use the pcnt hardware counter.   (The old code is preserved, and can be restored by removing the ```#define USE_PCNT``` at the top of ```FreqCountEsp.h```.

With this change, I am successful in measuring my 10 MHz xtal.  I also verified the modified code against the original by using both versions to measure a stabilized 32 kHz oscillator.