### PR TITLE
Support optional External Trigger for counting reference.

### DIFF
--- a/src/FreqCountESP.cpp
+++ b/src/FreqCountESP.cpp
@@ -4,14 +4,74 @@ volatile uint8_t _FreqCountESP::sIsFrequencyReady = false;
 volatile uint32_t _FreqCountESP::sCount = 0;
 volatile uint32_t _FreqCountESP::sFrequency = 0;
 
-portMUX_TYPE _FreqCountESP::sMux = portMUX_INITIALIZER_UNLOCKED;
+#ifdef USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
 
-void IRAM_ATTR onRise()
+volatile uint32_t _FreqCountESP::sLastPcnt = 0;
+
+#define PCNT_HIGH_LIMIT 32767  // largest +ve value for int16_t.
+#define PCNT_LOW_LIMIT  0
+
+#define PCNT_UNIT PCNT_UNIT_0
+#define PCNT_CHANNEL PCNT_CHANNEL_0
+
+portMUX_TYPE pcntMux = portMUX_INITIALIZER_UNLOCKED;
+
+static void IRAM_ATTR onHLim(void *backupCounter)
+{
+  // 16 bit pulse counter hit high limit; increment the 32 bit backup.
+  portENTER_CRITICAL_ISR(&pcntMux);
+  *(volatile uint32_t *)backupCounter += PCNT_HIGH_LIMIT;
+  PCNT.int_clr.val = BIT(PCNT_UNIT);  // Clear the interrupt.
+  portEXIT_CRITICAL_ISR(&pcntMux);
+}
+
+static pcnt_isr_handle_t setupPcnt(uint8_t pin, volatile uint32_t *backupCounter) { 
+  pcnt_config_t pcntConfig = {
+    .pulse_gpio_num = pin,
+    .ctrl_gpio_num = -1,
+    .pos_mode = PCNT_CHANNEL_EDGE_ACTION_INCREASE,
+    .neg_mode = PCNT_CHANNEL_EDGE_ACTION_HOLD,
+    .counter_h_lim = PCNT_HIGH_LIMIT,
+    .counter_l_lim = PCNT_LOW_LIMIT,
+    .unit = PCNT_UNIT,
+    .channel = PCNT_CHANNEL,
+  };
+  pcnt_unit_config(&pcntConfig);
+  pcnt_counter_pause(PCNT_UNIT);
+  pcnt_counter_clear(PCNT_UNIT);
+  pcnt_event_enable(PCNT_UNIT, PCNT_EVT_H_LIM);  // Interrupt on high limit.
+  pcnt_isr_handle_t isrHandle;
+  pcnt_isr_register(onHLim, (void *)backupCounter, 0, &isrHandle);
+  pcnt_intr_enable(PCNT_UNIT);
+  pcnt_counter_resume(PCNT_UNIT);
+  return isrHandle;
+}
+
+void IRAM_ATTR onTimer()
 {
   portENTER_CRITICAL_ISR(&_FreqCountESP::sMux);
-  _FreqCountESP::sCount++;
+  int16_t pulseCount;
+  uint32_t pcntTotal = _FreqCountESP::sCount;
+  pcnt_get_counter_value(PCNT_UNIT, &pulseCount);
+  if (pulseCount < 1000) {
+    // Maybe counter just rolled over? Re-read 32 bit basis.
+    pcntTotal = _FreqCountESP::sCount;
+  }
+  pcntTotal += pulseCount;
+  _FreqCountESP::sFrequency = (uint32_t)(pcntTotal - _FreqCountESP::sLastPcnt);
+  _FreqCountESP::sLastPcnt = pcntTotal;
+  _FreqCountESP::sIsFrequencyReady = true;
   portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
 }
+
+void teardownPcnt(pcnt_isr_handle_t isrHandle)
+{
+  pcnt_counter_pause(PCNT_UNIT);
+  pcnt_intr_disable(PCNT_UNIT);
+  pcnt_isr_unregister(isrHandle);
+}
+
+#else // !USE_PCNT
 
 void IRAM_ATTR onTimer()
 {
@@ -19,6 +79,16 @@ void IRAM_ATTR onTimer()
   _FreqCountESP::sFrequency = _FreqCountESP::sCount;
   _FreqCountESP::sCount = 0;
   _FreqCountESP::sIsFrequencyReady = true;
+  portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
+}
+#endif // !USE_PCNT
+
+portMUX_TYPE _FreqCountESP::sMux = portMUX_INITIALIZER_UNLOCKED;
+
+void IRAM_ATTR onRise()
+{
+  portENTER_CRITICAL_ISR(&_FreqCountESP::sMux);
+  _FreqCountESP::sCount++;
   portEXIT_CRITICAL_ISR(&_FreqCountESP::sMux);
 }
 
@@ -42,7 +112,12 @@ void _FreqCountESP::begin(uint8_t pin, uint16_t timerMs, uint8_t hwTimerId, uint
 
   pinMode(mPin, mode);
 
+#ifdef USE_PCNT
+  _FreqCountESP::sLastPcnt = 0;
+  mIsrHandle = setupPcnt(mPin, &_FreqCountESP::sCount);
+#else  // !USE_PCNT
   attachInterrupt(mPin, &onRise, RISING);
+#endif  // USE_PCNT
 
   mTimer = timerBegin(hwTimerId, 80, true);
   timerAttachInterrupt(mTimer, &onTimer, true);
@@ -63,7 +138,11 @@ uint8_t _FreqCountESP::available()
 
 void _FreqCountESP::end()
 {
+#ifdef USE_PCNT
+  teardownPcnt(mIsrHandle);
+#else 
   detachInterrupt(mPin);
+#endif
 
   timerAlarmDisable(mTimer);
   timerDetachInterrupt(mTimer);

--- a/src/FreqCountESP.cpp
+++ b/src/FreqCountESP.cpp
@@ -5,6 +5,8 @@ volatile uint32_t _FreqCountESP::sCount = 0;
 volatile uint32_t _FreqCountESP::sFrequency = 0;
 
 #ifdef USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
+// Thanks to jgustavoam and Rui Viana for tips gleaned from
+// https://www.esp32.com/viewtopic.php?t=17018
 
 volatile uint32_t _FreqCountESP::sLastPcnt = 0;
 

--- a/src/FreqCountESP.cpp
+++ b/src/FreqCountESP.cpp
@@ -120,9 +120,8 @@ void _FreqCountESP::_begin(uint8_t freqPin, uint8_t freqPinIOMode)
 #else  // !USE_PCNT
   attachInterrupt(mPin, &onRise, RISING);
 #endif  // USE_PCNT
-  if(mTriggerPin) {
-  } else {
-    // Start internal timer.
+  if(mTriggerPin == 0) {
+    // Not external trigger, start internal timer.
     timerAlarmEnable(mTimer);
   }
 }
@@ -146,7 +145,7 @@ void _FreqCountESP::beginExtTrig(uint8_t freqPin, uint8_t extTriggerPin, uint8_t
   assert(extTriggerPin > 0);
   mTriggerPin = extTriggerPin;
   pinMode(mTriggerPin, INPUT);
-  attachInterrupt(mTriggerPin, &onTimer, extTriggerMode);
+  attachInterrupt(digitalPinToInterrupt(mTriggerPin), &onTimer, extTriggerMode);
 
   _begin(freqPin, freqPinIOMode);
 }
@@ -169,10 +168,13 @@ void _FreqCountESP::end()
 #else 
   detachInterrupt(mPin);
 #endif
-
-  timerAlarmDisable(mTimer);
-  timerDetachInterrupt(mTimer);
-  timerEnd(mTimer);
+  if(mTriggerPin == 0) {
+    timerAlarmDisable(mTimer);
+    timerDetachInterrupt(mTimer);
+    timerEnd(mTimer);
+  } else {
+    detachInterrupt(digitalPinToInterrupt(mTriggerPin));
+  }
 }
 
 _FreqCountESP FreqCountESP;

--- a/src/FreqCountESP.h
+++ b/src/FreqCountESP.h
@@ -3,6 +3,15 @@
 
 #include <Arduino.h>
 
+#define USE_PCNT  // Use ESP32 hardware pulse counter instead of per-pulse ISR.
+
+#ifdef USE_PCNT
+extern "C" {
+  #include "soc/pcnt_struct.h"
+}
+#include <driver/pcnt.h>
+#endif
+
 void IRAM_ATTR onRise();
 void IRAM_ATTR onTimer();
 
@@ -12,11 +21,17 @@ private:
   uint8_t mPin;
   uint16_t mTimerMs;
   hw_timer_t *mTimer;
+#ifdef USE_PCNT
+  pcnt_isr_handle_t mIsrHandle;
+#endif
 
 public:
   static volatile uint8_t sIsFrequencyReady;
   static volatile uint32_t sCount;
   static volatile uint32_t sFrequency;
+#ifdef USE_PCNT
+  static volatile uint32_t sLastPcnt;
+#endif
 
   static portMUX_TYPE sMux;
 

--- a/src/FreqCountESP.h
+++ b/src/FreqCountESP.h
@@ -19,11 +19,12 @@ class _FreqCountESP
 {
 private:
   uint8_t mPin;
-  uint16_t mTimerMs;
+  uint8_t mTriggerPin;
   hw_timer_t *mTimer;
 #ifdef USE_PCNT
   pcnt_isr_handle_t mIsrHandle;
 #endif
+  void _begin(uint8_t freqPin, uint8_t freqPinIOMode);
 
 public:
   static volatile uint8_t sIsFrequencyReady;
@@ -38,7 +39,10 @@ public:
   _FreqCountESP();
   ~_FreqCountESP();
 
-  void begin(uint8_t pin, uint16_t timerMs, uint8_t hwTimerId = 0, uint8_t mode = INPUT);
+  // Frequency counter using internal interval timer.
+  void begin(uint8_t pin, uint16_t timerMs, uint8_t hwTimerId = 0, uint8_t freqPinIOMode = INPUT);
+  // Frequency counter using external trigger pulse input.
+    void beginExtTrig(uint8_t pin, uint8_t extTriggerPin, uint8_t freqPinIOMode = INPUT, uint8_t extTriggerMode = RISING);
   uint32_t read();
   uint8_t available();
   void end();


### PR DESCRIPTION
Hello, me again.

To better measure the accuracy of my 10 MHz xtal, I wanted to use an external 1PPS reference signal (from a GPS receiver) to trigger the pulse counts.  This change enables this mode, selected by a different initializer call. 

I found that the internal interval counter was ~15ppm slow compared to the external 1PPS reference.  That's insignificant for many applications, but I'm trying to measure accuracy in the parts per *billion*.

This change is layered on top of my previous PR to use the ESP32 hardware pulse counter (to allow it to count frequencies as high as 10MHz).  However, the change is in principal independent of that change.